### PR TITLE
escape column names in comments

### DIFF
--- a/dbt/include/clickhouse/macros/persist_docs.sql
+++ b/dbt/include/clickhouse/macros/persist_docs.sql
@@ -3,7 +3,7 @@
 {% endmacro %}
 
 {% macro one_alter_column_comment(relation, column_name, comment) %}
-  alter table {{ relation }} {{ on_cluster_clause(relation) }} comment column {{ column_name }} '{{ comment }}'
+  alter table {{ relation }} {{ on_cluster_clause(relation) }} comment column `{{ column_name }}` '{{ comment }}'
 {% endmacro %}
 
 {% macro clickhouse__alter_relation_comment(relation, comment) %}
@@ -24,7 +24,7 @@
       {%- set comment = model.columns[column_name]['description'] -%}
       {%- if comment %}
         {% set escaped_comment = clickhouse_escape_comment(comment) %}
-        {% do alter_comments.append("comment column {column_name} {comment}".format(column_name=column_name, comment=escaped_comment)) %}
+        {% do alter_comments.append("comment column `{column_name}` {comment}".format(column_name=column_name, comment=escaped_comment)) %}
       {%- endif %}
     {%- endfor -%}
   {%- endif -%}


### PR DESCRIPTION
## Summary
Escapes column names when generating comments via persist_docs. https://github.com/ClickHouse/dbt-clickhouse/issues/427



## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided to include in CHANGELO